### PR TITLE
Revert "Fix drift file on Debian"

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -100,8 +100,8 @@ class ntp::params {
   }
 
   $drift_file = $::operatingsystem ? {
-    /(?i:Ubuntu|Mint|Solaris)/ => "$data_dir/ntp.drift",
-    default                    => "$data_dir/drift",
+    /(?i:Debian|Ubuntu|Mint|Solaris)/ => "$data_dir/ntp.drift",
+    default                           => "$data_dir/drift",
   }
 
   $use_local_clock = $::virtual ? {


### PR DESCRIPTION
This reverts commit ae3154856acadd9bd82cce25a3709ee11516fcd9.

Proof: http://anonscm.debian.org/viewvc/pkg-ntp/ntp/trunk/debian/ntp.conf?view=markup
