### PR TITLE
$ntp::params::server must be an array so that the ntp.conf.erb parses co...

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,7 @@
 class ntp::params {
 
   ### Module specific parameters
-  $server = 'pool.ntp.org'
+  $server = [ '0.pool.ntp.org', '1.pool.ntp.org', '2.pool.ntp.org', '3.pool.ntp.org' ]
   $runmode = 'service'
   $keys_file = $::operatingsystem ? {
     'Solaris' => '/etc/inet/ntp.keys',


### PR DESCRIPTION
...rrectly.
