### PR TITLE
Don't remove the permission to the daemon

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -77,7 +77,8 @@ class ntp::params {
   }
 
   $config_file_mode = $::operatingsystem ? {
-    default => '0640',
+    /(?i:SLES|OpenSuSE)/ => '0640',
+    default              => '0644',
   }
 
   $config_file_owner = $::operatingsystem ? {


### PR DESCRIPTION
On Debian, stock ntpd is run as ntp:ntp and config is root:root with mode 0644, previous fix was reserving the config to root
